### PR TITLE
Support passing a partial object in typings

### DIFF
--- a/search-bounds.d.ts
+++ b/search-bounds.d.ts
@@ -1,11 +1,12 @@
 declare module 'binary-search-bounds' {
     interface BSearch {
-        gt<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number);
-        ge<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number);
-        lt<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number);
-        le<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number);
-        eq<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number);
+        gt<T>(array: T[], y: Partial<T>, compare?: ((a: T, b: T) => number | null | undefined), lo?: number, hi?: number): number;
+        ge<T>(array: T[], y: Partial<T>, compare?: ((a: T, b: T) => number | null | undefined), lo?: number, hi?: number): number;
+        lt<T>(array: T[], y: Partial<T>, compare?: ((a: T, b: T) => number | null | undefined), lo?: number, hi?: number): number;
+        le<T>(array: T[], y: Partial<T>, compare?: ((a: T, b: T) => number | null | undefined), lo?: number, hi?: number): number;
+        eq<T>(array: T[], y: Partial<T>, compare?: ((a: T, b: T) => number | null | undefined), lo?: number, hi?: number): number;
     }
-    const bsearch:BSearch;
+    
+    const bsearch: BSearch;
     export = bsearch;
 }


### PR DESCRIPTION
Now examples in README.md are consistent with typings.