### PR TITLE
Fix typings: specify return value

### DIFF
--- a/search-bounds.d.ts
+++ b/search-bounds.d.ts
@@ -1,10 +1,10 @@
 declare module 'binary-search-bounds' {
     interface BSearch {
-        gt<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number);
-        ge<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number);
-        lt<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number);
-        le<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number);
-        eq<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number);
+        gt<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number): number;
+        ge<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number): number;
+        lt<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number): number;
+        le<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number): number;
+        eq<T>(array:T[], y:T, compare?:((a:T, b:T) => number | null | undefined), lo?:number, hi?:number): number;
     }
     const bsearch:BSearch;
     export = bsearch;


### PR DESCRIPTION
Really useful library! This fixes the typings for the methods, they all need return a number (not `any`).